### PR TITLE
De-stringify the model (use type Model instead of Map<string,int>)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ package-lock.json
 *.fs.js
 .fake
 .ionide
+.vscode/settings.json
+public/bundle.js

--- a/src/App/App.fs
+++ b/src/App/App.fs
@@ -12,16 +12,13 @@ module Main =
 
     let grids =
         let divs =
-            Html.div
-                [ Attr.style "display: flex"
-                  unsubscribeOnUnmount [ interval updateStore 500 ]
-                  Bind.el (peopleStore, (fun ps -> generateGrid (getState "rowCount") (getState "colCount") ps)) ]
+            Html.div [ Attr.style "display: flex"
+                       unsubscribeOnUnmount [ interval updateStore 500 ]
+                       Bind.el (peopleStore, (fun ps -> generateGrid (getState().RowCount) (getState().ColCount) ps)) ]
 
         Html.div divs
 
-    Html.div
-        [ Attr.style [ Css.marginLeft 5; Css.marginRight 5 ]
-          Html.div [ form ]
-          grids
-          chart ]
-    |> Program.mountElement "adoption-sim"
+    let view () =
+        Html.div [ Attr.style [ Css.marginLeft 5; Css.marginRight 5 ]; Html.div [ form ]; grids; chart ]
+
+    Program.mount ("sutil-app", view ())

--- a/src/App/View.fs
+++ b/src/App/View.fs
@@ -93,9 +93,9 @@ module View =
                           prop.text "Marketing spend" ] ]
 
               Bind.el (
-                  stateStore |> Store.mapDistinct (fun sw -> sw["running"]),
+                  stateStore |> Store.mapDistinct (fun m -> m.Running),
                   fun isRunning ->
-                      if (isRunning = 1) then
+                      if (isRunning) then
                           Html.button
                               [ Attr.className "button"
                                 Attr.style [ Css.marginTop (rem 1); Css.marginRight (rem 1) ]
@@ -116,7 +116,7 @@ module View =
                     prop.text "Reset"
                     Ev.onClick (fun _ -> resetSimulation stateStore)
                     Bulma.color.isDark ]
-              Html.div [ Bind.el (stateStore, (fun t -> string t["ticks"] |> prop.text)) ]
+              Html.div [ Bind.el (stateStore, (fun m -> m.Ticks |> string |> prop.text)) ]
 
               ]
 


### PR DESCRIPTION
We don't need to stringify the main model state. See `type Model` usage instead of `Map<string,int>`.

This makes the code much more type-safe, and removes a lot of code-contortion in trying to update model ticks. For example:

Before:
```fs
             if ((Store.get stateStore)["running"] = 1) then
                 let t = (Store.get stateStore)["ticks"] + 1
                 stateStore <~= (fun m -> m.Change("ticks", (fun _ -> Some t)))
```

After:
```fs
             if getState().Running then
                 stateStore <~= (fun m -> { m with Ticks = m.Ticks + 1})
```

(I would *expect* this code to be faster too, but experience tells me to let a profiler decide that)

I will email as a follow-up.

